### PR TITLE
fix(deps): revert to v3 core libraries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.24.1
 
 require (
 	github.com/launchdarkly/go-sdk-common/v3 v3.5.0
-	github.com/launchdarkly/go-server-sdk/v7 v7.15.3-0.20260610192009-fb2518b505b3
+	github.com/launchdarkly/go-server-sdk/v7 v7.15.3
 )
 
 require (
@@ -16,7 +16,7 @@ require (
 	github.com/launchdarkly/ccache v1.1.0 // indirect
 	github.com/launchdarkly/eventsource v1.10.0 // indirect
 	github.com/launchdarkly/go-jsonstream/v3 v3.1.1 // indirect
-	github.com/launchdarkly/go-sdk-events/v3 v3.6.2-0.20260610185926-04050b02df99 // indirect
+	github.com/launchdarkly/go-sdk-events/v3 v3.6.2 // indirect
 	github.com/launchdarkly/go-semver v1.0.3 // indirect
 	github.com/launchdarkly/go-server-sdk-evaluation/v3 v3.0.1 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,19 +5,21 @@ go 1.24.0
 toolchain go1.24.1
 
 require (
-	github.com/launchdarkly/go-sdk-common/v4 v4.0.0
-	github.com/launchdarkly/go-server-sdk/v7 v7.15.2
+	github.com/launchdarkly/go-sdk-common/v3 v3.5.0
+	github.com/launchdarkly/go-server-sdk/v7 v7.15.3-0.20260610192009-fb2518b505b3
 )
 
 require (
 	github.com/google/uuid v1.1.1 // indirect
 	github.com/gregjones/httpcache v0.0.0-20171119193500-2bcd89a1743f // indirect
+	github.com/josharian/intern v1.0.0 // indirect
 	github.com/launchdarkly/ccache v1.1.0 // indirect
 	github.com/launchdarkly/eventsource v1.10.0 // indirect
-	github.com/launchdarkly/go-jsonstream/v4 v4.0.0 // indirect
-	github.com/launchdarkly/go-sdk-events/v3 v3.6.1 // indirect
+	github.com/launchdarkly/go-jsonstream/v3 v3.1.1 // indirect
+	github.com/launchdarkly/go-sdk-events/v3 v3.6.2-0.20260610185926-04050b02df99 // indirect
 	github.com/launchdarkly/go-semver v1.0.3 // indirect
-	github.com/launchdarkly/go-server-sdk-evaluation/v4 v4.0.0 // indirect
+	github.com/launchdarkly/go-server-sdk-evaluation/v3 v3.0.1 // indirect
+	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	golang.org/x/sync v0.8.0 // indirect
 )

--- a/main.go
+++ b/main.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/launchdarkly/go-sdk-common/v4/ldcontext"
-	"github.com/launchdarkly/go-sdk-common/v4/ldvalue"
+	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
+	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
 	ld "github.com/launchdarkly/go-server-sdk/v7"
 )
 


### PR DESCRIPTION
## Summary

Reverts the hello-go example app off the `/v4` core libraries back to the latest **v3** modules and the reverted go-server-sdk, matching the ecosystem-wide rollback. The `/v4` major bump is a breaking change for customers under Go semantic import versioning.

`go-server-sdk` is pinned to a pseudo-version of its revert branch until v7.15.3 releases.

Jira: [SDK-2496](https://launchdarkly.atlassian.net/browse/SDK-2496)

## Changes
- `go.mod`: core deps → `go-sdk-common v3.5.0`, `go-jsonstream v3.1.1`, `go-server-sdk-evaluation v3.0.1`, `go-server-sdk` reverted pseudo.
- Rewrote `/v4` → `/v3` import paths.
- `go build`/`go vet` pass. (Example app — no release.)

[SDK-2496]: https://launchdarkly.atlassian.net/browse/SDK-2496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ